### PR TITLE
Use fixed image for github action

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Update-Data-Job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
To avoid data update breaking by "latest" becoming a newer version.